### PR TITLE
Free soundfont memory after render

### DIFF
--- a/src/paramidib.nim
+++ b/src/paramidib.nim
@@ -14,6 +14,7 @@ template saveMusic*(wavFile: string, score: untyped) =
   const sampleRate = 44100
   tsf_set_output(sf, TSF_MONO, sampleRate, 0)
   var res = render[cshort](compile(scoreObject), sf, sampleRate)
+  tsf_close(sf)
   # create the wav file (without playing it)
   common.writeFile(wavFile, res.data, res.data.len.uint32, sampleRate)
 


### PR DESCRIPTION
The joys of working with C code :D I forgot to free the soundfont in all my examples so it was leaking memory. Maybe not a big deal if it's a short running program but i though i'd add it here too.